### PR TITLE
Add Workflow Actions

### DIFF
--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -3,7 +3,6 @@
 from collective.sidebar.utils import crop
 from collective.sidebar.utils import get_translated
 from collective.sidebar.utils import get_user
-from collective.sidebar.utils import get_workflow_data
 from plone import api
 from plone.app.layout.viewlets.common import ViewletBase
 from Products.CMFCore.interfaces import IFolderish
@@ -184,11 +183,32 @@ class SidebarViewlet(ViewletBase):
         else:
             return parent_url
 
-    def get_workflow(self):
+    def get_workflow_data(self):
         """
-        Return options for the workflow.
+        Return the workflow data for the context.
         """
-        return get_workflow_data(self.context)
+        portal_workflow = api.portal.get_tool('portal_workflow')
+        transitions = portal_workflow.getTransitionsFor(self.context)
+        result = {
+            'state': {
+                'name': '',
+                'color': 'sidebar-blue',
+            },
+            'transitions': [],
+        }
+        if transitions:
+            # Get the current state
+            state = api.content.get_state(self.context, None)
+            # Set a color for the state
+            if state == 'private':
+                result['state']['color'] = 'sidebar-red'
+            elif state == 'pending':
+                result['state']['color'] = 'sidebar-yellow'
+            elif state == 'visible':
+                result['state']['color'] = 'sidebar-purple'
+            result['state']['name'] = get_translated(state, self)
+            result['transitions'] = transitions
+        return result
 
 
 class CoverViewlet(SidebarViewlet):

--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -210,6 +210,102 @@ class SidebarViewlet(ViewletBase):
             result['transitions'] = transitions
         return result
 
+    def getMenuItems(self):
+        """Return menu item entries in a TAL-friendly form."""
+        context = self.context
+        request = context.REQUEST
+        from plone.app.contentmenu import PloneMessageFactory as _
+        from zope.component import queryMultiAdapter
+        from Products.CMFCore.utils import getToolByName
+        from plone.protect.utils import addTokenToUrl
+        from Products.CMFCore.utils import _checkPermission
+        import pkg_resources
+        try:
+            pkg_resources.get_distribution('Products.CMFPlacefulWorkflow')
+            from Products.CMFPlacefulWorkflow.permissions import \
+                ManageWorkflowPolicies
+        except pkg_resources.DistributionNotFound:
+            from Products.CMFCore.permissions import \
+                ManagePortal as ManageWorkflowPolicies  # noqa
+
+        results = []
+
+        locking_info = queryMultiAdapter((context, request),
+                                         name='plone_lock_info')
+        if locking_info and locking_info.is_locked_for_current_user():
+            return []
+
+        wf_tool = getToolByName(context, 'portal_workflow')
+        workflowActions = wf_tool.listActionInfos(object=context)
+
+        for action in workflowActions:
+            if action['category'] != 'workflow':
+                continue
+
+            cssClass = ''
+            actionUrl = action['url']
+            if actionUrl == '':
+                actionUrl = '{0}/content_status_modify?workflow_action={1}'
+                actionUrl = actionUrl.format(
+                    context.absolute_url(),
+                    action['id'],
+                )
+                cssClass = ''
+
+            description = ''
+
+            transition = action.get('transition', None)
+            if transition is not None:
+                description = transition.description
+
+            if action['allowed']:
+                results.append({
+                    'title': action['title'],
+                    'description': description,
+                    'action': addTokenToUrl(actionUrl, request),
+                    'selected': False,
+                    'icon': None,
+                    'extra': {
+                        'id': 'workflow-transition-{0}'.format(action['id']),
+                        'separator': None,
+                        'class': cssClass},
+                    'submenu': None,
+                })
+
+        url = context.absolute_url()
+
+        if len(results) > 0:
+            results.append({
+                'title': _(u'label_advanced', default=u'Advanced...'),
+                'description': '',
+                'action': url + '/content_status_history',
+                'selected': False,
+                'icon': None,
+                'extra': {
+                    'id': 'workflow-transition-advanced',
+                    'separator': 'actionSeparator',
+                    'class': 'pat-plone-modal'},
+                'submenu': None,
+            })
+
+        pw = getToolByName(context, 'portal_placeful_workflow', None)
+        if pw is not None:
+            if _checkPermission(ManageWorkflowPolicies, context):
+                results.append({
+                    'title': _(u'workflow_policy',
+                               default=u'Policy...'),
+                    'description': '',
+                    'action': url + '/placeful_workflow_configuration',
+                    'selected': False,
+                    'icon': None,
+                    'extra': {'id': 'workflow-transition-policy',
+                              'separator': None,
+                              'class': ''},
+                    'submenu': None,
+                })
+
+        return results
+
 
 class CoverViewlet(SidebarViewlet):
 

--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -3,6 +3,7 @@
 from collective.sidebar.utils import crop
 from collective.sidebar.utils import get_translated
 from collective.sidebar.utils import get_user
+from collective.sidebar.utils import get_workflow_data
 from plone import api
 from plone.app.layout.viewlets.common import ViewletBase
 from Products.CMFCore.interfaces import IFolderish
@@ -182,6 +183,12 @@ class SidebarViewlet(ViewletBase):
             return context_url
         else:
             return parent_url
+
+    def get_workflow(self):
+        """
+        Return options for the workflow.
+        """
+        return get_workflow_data(self.context)
 
 
 class CoverViewlet(SidebarViewlet):

--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -210,7 +210,7 @@ class SidebarViewlet(ViewletBase):
             result['transitions'] = transitions
         return result
 
-    def getMenuItems(self):
+    def get_workflow_actions(self):
         """Return menu item entries in a TAL-friendly form."""
         context = self.context
         request = context.REQUEST
@@ -273,20 +273,6 @@ class SidebarViewlet(ViewletBase):
                 })
 
         url = context.absolute_url()
-
-        if len(results) > 0:
-            results.append({
-                'title': _(u'label_advanced', default=u'Advanced...'),
-                'description': '',
-                'action': url + '/content_status_history',
-                'selected': False,
-                'icon': None,
-                'extra': {
-                    'id': 'workflow-transition-advanced',
-                    'separator': 'actionSeparator',
-                    'class': 'pat-plone-modal'},
-                'submenu': None,
-            })
 
         pw = getToolByName(context, 'portal_placeful_workflow', None)
         if pw is not None:

--- a/src/collective/sidebar/browser/static/cover.less
+++ b/src/collective/sidebar/browser/static/cover.less
@@ -1,5 +1,5 @@
 #portal-navigation-cover {
-  background: @black;
+  background: @sidebar-black;
   height: 100%;
   left: 0;
   opacity: 0;

--- a/src/collective/sidebar/browser/static/main.less
+++ b/src/collective/sidebar/browser/static/main.less
@@ -11,9 +11,46 @@
 @screen-lg-min: 1200px;
 
 // Default Colors
-@black: #2F3334;
-@grey: #EBECEF;
-@white: #FAFAFA;
+@sidebar-black: #2F3334;
+@sidebar-blue: #42A5F5;
+@sidebar-green: #66BB6A;
+@sidebar-grey: #EBECEF;
+@sidebar-purple: #7B1FA2;
+@sidebar-red: #F44336;
+@sidebar-white: #FAFAFA;
+@sidebar-yellow: #FDD835;
+
+.sidebar-black {
+  color: @sidebar-black;
+}
+
+.sidebar-blue {
+  color: @sidebar-blue;
+}
+
+.sidebar-green {
+  color: @sidebar-green;
+}
+
+.sidebar-grey {
+  color: @sidebar-grey;
+}
+
+.sidebar-purple {
+  color: @sidebar-purple;
+}
+
+.sidebar-red {
+  color: @sidebar-red;
+}
+
+.sidebar-white {
+  color: @sidebar-white;
+}
+
+.sidebar-yellow {
+  color: @sidebar-yellow;
+}
 
 /* Imports */
 @import './cover.less';

--- a/src/collective/sidebar/browser/static/sidebar.less
+++ b/src/collective/sidebar/browser/static/sidebar.less
@@ -36,7 +36,7 @@
   }
 
   .menu {
-    background-color: @white;
+    background-color: @sidebar-white;
     height: 100%;
     overflow-x: hidden;
     overflow-y: scroll;
@@ -54,7 +54,7 @@
     a:focus,
     a:active,
     a:visited {
-      color: @black;
+      color: @sidebar-black;
       display: block;
       font-weight: 400;
       margin-bottom: 15px;

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -52,7 +52,7 @@
       <!-- Workflow -->
 
       <div class="menu-section"
-           tal:define="data view/get_workflow;
+           tal:define="data view/get_workflow_data;
                        absolute_url context/absolute_url;
                        content_status_modify python:absolute_url + '/content_status_modify';
                        state python:data['state'];
@@ -66,12 +66,12 @@
         </a>
 
         <a href="#">
-          <span class="menu-item-icon glyphicon glyphicon-record"></span> <span class="menu-item-title">${state/title}</span>
+          <span class="menu-item-icon glyphicon glyphicon-record ${state/color}"></span> <span class="menu-item-title">${state/name/title}</span>
         </a>
 
         <tal:repeat tal:repeat="transition transitions">
-          <a href="${content_status_modify}?workflow_action=${transition}${token_arg}">
-            <span class="menu-item-icon glyphicon glyphicon-transfer"></span> <span class="menu-item-title">${transition/title}</span>
+          <a href="${content_status_modify}?workflow_action=${transition/id}${token_arg}" title="${transition/title}">
+            <span class="menu-item-icon glyphicon glyphicon-transfer"></span> <span class="menu-item-title">${transition/name}</span>
           </a>
         </tal:repeat>
 

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -4,7 +4,9 @@
 
   <nav id="portal-navigation"
        tal:define="items view/get_items;
-                   root_items python:view.get_items(root=True)"
+                   root_items python:view.get_items(root=True);
+                   token context/@@authenticator/token;
+                   token_arg python:'&amp;_authenticator=' + token"
        i18n:domain="collective.sidebar">
 
     <div class="menu">
@@ -44,6 +46,34 @@
             <span class="menu-item-icon glyphicon glyphicon-log-out"></span> <span class="menu-item-title" i18n:translate="navigation_link_logout">Logout</span>
           </a>
         </tal:item>
+
+      </div>
+
+      <!-- Workflow -->
+
+      <div class="menu-section"
+           tal:define="data view/get_workflow;
+                       absolute_url context/absolute_url;
+                       content_status_modify python:absolute_url + '/content_status_modify';
+                       state python:data['state'];
+                       transitions python:data['transitions']"
+           tal:condition="python:view.can_edit() and transitions">
+
+        <a href="${absolute_url}/content_status_history" i18n:translate="navigation_heading_workflow">
+          <div class="menu-section-title">
+            Workflow
+          </div>
+        </a>
+
+        <a href="#">
+          <span class="menu-item-icon glyphicon glyphicon-record"></span> <span class="menu-item-title">${state/title}</span>
+        </a>
+
+        <tal:repeat tal:repeat="transition transitions">
+          <a href="${content_status_modify}?workflow_action=${transition}${token_arg}">
+            <span class="menu-item-icon glyphicon glyphicon-transfer"></span> <span class="menu-item-title">${transition/title}</span>
+          </a>
+        </tal:repeat>
 
       </div>
 

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -52,28 +52,28 @@
       <!-- Workflow -->
 
       <div class="menu-section"
-        i18n:domain="plone"
         tal:define="data view/get_workflow_data;
                        absolute_url context/absolute_url;
                        content_status_modify python:absolute_url + '/content_status_modify';
-                       state python:data['state'];"
+                       state python:data['state'];
+                       actions view/get_workflow_actions;"
         tal:condition="python:view.can_edit()">
 
-        <a href="${absolute_url}/content_status_history" i18n:translate="navigation_heading_workflow">
-          <div class="menu-section-title">
-            Workflow
-          </div>
-        </a>
+        <div class="menu-section-title" i18n:translate="navigation_heading_workflow">Workflow</div>
 
-        <a href="#">
+        <a href="#" i18n:domain="plone">
           <span class="menu-item-icon glyphicon glyphicon-record ${state/color}"></span> <span class="menu-item-title">${state/name/title}</span>
         </a>
 
-        <tal:repeat tal:repeat="action view/getMenuItems">
-          <a href="${action/action}">
+        <tal:repeat tal:repeat="action actions">
+          <a href="${action/action}" i18n:domain="plone">
             <span class="menu-item-icon glyphicon glyphicon-transfer"></span> <span class="menu-item-title" i18n:translate="">${action/title}</span>
           </a>
         </tal:repeat>
+
+        <a href="${absolute_url}/content_status_history" tal:condition="actions">
+          <span class="menu-item-icon glyphicon glyphicon-option-horizontal"></span> <span class="menu-item-title" i18n:translate="sidebar_workflow_advanced">Advanced</span>
+        </a>
 
       </div>
 

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -52,12 +52,12 @@
       <!-- Workflow -->
 
       <div class="menu-section"
-           tal:define="data view/get_workflow_data;
+        i18n:domain="plone"
+        tal:define="data view/get_workflow_data;
                        absolute_url context/absolute_url;
                        content_status_modify python:absolute_url + '/content_status_modify';
-                       state python:data['state'];
-                       transitions python:data['transitions']"
-           tal:condition="python:view.can_edit() and transitions">
+                       state python:data['state'];"
+        tal:condition="python:view.can_edit()">
 
         <a href="${absolute_url}/content_status_history" i18n:translate="navigation_heading_workflow">
           <div class="menu-section-title">
@@ -69,9 +69,9 @@
           <span class="menu-item-icon glyphicon glyphicon-record ${state/color}"></span> <span class="menu-item-title">${state/name/title}</span>
         </a>
 
-        <tal:repeat tal:repeat="transition transitions">
-          <a href="${content_status_modify}?workflow_action=${transition/id}${token_arg}" title="${transition/title}">
-            <span class="menu-item-icon glyphicon glyphicon-transfer"></span> <span class="menu-item-title">${transition/name}</span>
+        <tal:repeat tal:repeat="action view/getMenuItems">
+          <a href="${action/action}">
+            <span class="menu-item-icon glyphicon glyphicon-transfer"></span> <span class="menu-item-title" i18n:translate="">${action/title}</span>
           </a>
         </tal:repeat>
 

--- a/src/collective/sidebar/locales/collective.sidebar.pot
+++ b/src/collective/sidebar/locales/collective.sidebar.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-18 09:27+0000\n"
+"POT-Creation-Date: 2018-10-18 16:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,9 +73,19 @@ msgstr ""
 msgid "navigation_heading_navigation"
 msgstr ""
 
+#. Default: "Search"
+#: collective/sidebar/browser/templates/sidebar.pt
+msgid "navigation_heading_search"
+msgstr ""
+
 #. Default: "Site"
 #: collective/sidebar/browser/templates/sidebar.pt
 msgid "navigation_heading_site"
+msgstr ""
+
+#. Default: "Workflow"
+#: collective/sidebar/browser/templates/sidebar.pt
+msgid "navigation_heading_workflow"
 msgstr ""
 
 #. Default: "Home"
@@ -108,7 +118,17 @@ msgstr ""
 msgid "sharing"
 msgstr ""
 
+#. Default: "Advanced"
+#: collective/sidebar/browser/templates/sidebar.pt
+msgid "sidebar_workflow_advanced"
+msgstr ""
+
 #. Default: "View"
 #: collective/sidebar/browser/templates/sidebar.pt
 msgid "view"
+msgstr ""
+
+#. Default: "Policy..."
+#: collective/sidebar/browser/sidebar.py
+msgid "workflow_policy"
 msgstr ""

--- a/src/collective/sidebar/locales/de/LC_MESSAGES/collective.sidebar.po
+++ b/src/collective/sidebar/locales/de/LC_MESSAGES/collective.sidebar.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-18 09:27+0000\n"
+"POT-Creation-Date: 2018-10-18 16:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -70,10 +70,20 @@ msgstr "Links"
 msgid "navigation_heading_navigation"
 msgstr "Navigation"
 
+#. Default: "Search"
+#: collective/sidebar/browser/templates/sidebar.pt
+msgid "navigation_heading_search"
+msgstr "Suche"
+
 #. Default: "Site"
 #: collective/sidebar/browser/templates/sidebar.pt
 msgid "navigation_heading_site"
 msgstr "Webseite"
+
+#. Default: "Workflow"
+#: collective/sidebar/browser/templates/sidebar.pt
+msgid "navigation_heading_workflow"
+msgstr "Arbeitsablauf"
 
 #. Default: "Home"
 #: collective/sidebar/browser/templates/sidebar.pt
@@ -105,7 +115,17 @@ msgstr "Standardseite"
 msgid "sharing"
 msgstr "Freigabe"
 
+#. Default: "Advanced"
+#: collective/sidebar/browser/templates/sidebar.pt
+msgid "sidebar_workflow_advanced"
+msgstr "Erweitert"
+
 #. Default: "View"
 #: collective/sidebar/browser/templates/sidebar.pt
 msgid "view"
 msgstr "Anzeigen"
+
+#. Default: "Policy..."
+#: collective/sidebar/browser/sidebar.py
+msgid "workflow_policy"
+msgstr "Richtlinien"

--- a/src/collective/sidebar/utils.py
+++ b/src/collective/sidebar/utils.py
@@ -55,22 +55,3 @@ def get_user():
     user_id = user.id
     user_dir = '/users/{0}'.format(user_id)
     return user, user_id, user_dir
-
-
-def get_workflow_data(context):
-    """
-    Return the workflow data for the context.
-    """
-    portal_workflow = api.portal.get_tool('portal_workflow')
-    workflows = portal_workflow.getWorkflowsFor(context)
-    result = {
-        'state': '',
-        'transitions': list(),
-    }
-    if workflows:
-        workflow = workflows[0]
-        state = api.content.get_state(context, None)
-        transitions = getattr(workflow.states, state).transitions
-        result['state'] = state
-        result['transitions'] = transitions
-    return result

--- a/src/collective/sidebar/utils.py
+++ b/src/collective/sidebar/utils.py
@@ -55,3 +55,22 @@ def get_user():
     user_id = user.id
     user_dir = '/users/{0}'.format(user_id)
     return user, user_id, user_dir
+
+
+def get_workflow_data(context):
+    """
+    Return the workflow data for the context.
+    """
+    portal_workflow = api.portal.get_tool('portal_workflow')
+    workflows = portal_workflow.getWorkflowsFor(context)
+    result = {
+        'state': '',
+        'transitions': list(),
+    }
+    if workflows:
+        workflow = workflows[0]
+        state = api.content.get_state(context, None)
+        transitions = getattr(workflow.states, state).transitions
+        result['state'] = state
+        result['transitions'] = transitions
+    return result


### PR DESCRIPTION
Adds the workflow actions menu to the sidebar, allowing the state transition to be changed on the context object. States are styled similarly to Plone default in that Private is red, Pending is yellow and Published is blue etc...

Permissions work with the Modify Portal Content permission as default. See here https://github.com/plone/plone.app.content/blob/master/plone/app/content/browser/contents/workflow.py#L39.