### PR TITLE
#22 Sidebar Static Action Links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 Added:
 
 - Added a profile section to the top of the sidebar panel. #5
+- Sidebar links are now configurable through the portal_actions menu. #22
   [netroxen]
 
 

--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,19 @@ Features
 - Includes workflow state management
 - Includes site navigation
 - Includes quick access to the user profile
+- Includes configurable persistent site links through the ZMI
 
 
 Examples
 --------
 
 - TBD
+
+
+Documentation
+-------------
+
+Full documentation for end users can be found in the "docs" folder.
 
 
 Translations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,13 @@
 ==================
-collective.sidebar
+User Documentation
 ==================
 
-User Documentation
+
+Sidebar Links (portal_actions)
+------------------------------
+
+The sidebar links are configured through the Plone ``portal_actions`` menu in the ZMI.
+
+To change the links displayed in the sidebar, navigate to your Plone instance in the ZMI (you must be logged in as an administrator) and then the ``sidebar_links (Sidebar Links)`` action category.
+
+Here you can either add a new ``CMF Action`` or edit / delete any of the existing links displayed in the sidebar. It is recommended to leave the default actions for the sake of usability though.

--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -47,6 +47,23 @@ class SidebarViewlet(ViewletBase):
         """
         return api.portal.get().absolute_url()
 
+    def get_sidebar_links(self):
+        """
+        Return sidebar links from portal_actions.
+        """
+        cx = self.context
+        filtered = cx.portal_actions.listFilteredActionsFor(cx)
+        sidebar_links = filtered.get('sidebar_links', [])
+        return sidebar_links
+
+    def get_user_profile_url(self):
+        """
+        Return URL for the user profile.
+        """
+        portal_url = self.get_portal_url()
+        portal_user = get_user()[2]
+        return portal_url + portal_user
+
     def get_user_data(self):
         user = get_user()
         mtool = api.portal.get_tool('portal_membership')

--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -56,14 +56,6 @@ class SidebarViewlet(ViewletBase):
         sidebar_links = filtered.get('sidebar_links', [])
         return sidebar_links
 
-    def get_user_profile_url(self):
-        """
-        Return URL for the user profile.
-        """
-        portal_url = self.get_portal_url()
-        portal_user = get_user()[2]
-        return portal_url + portal_user
-
     def get_user_data(self):
         user = get_user()
         mtool = api.portal.get_tool('portal_membership')

--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -47,7 +47,7 @@ class SidebarViewlet(ViewletBase):
         """
         return api.portal.get().absolute_url()
 
-    def get_sidebar_links(self):
+    def get_static_links(self):
         """
         Return sidebar links from portal_actions.
         """

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -45,27 +45,16 @@
 
       </div>
 
-      <div class="menu-section">
+      <div class="menu-section" tal:define="links view/get_sidebar_links">
 
         <div class="menu-section-title" i18n:translate="navigation_heading_links">Links</div>
 
-        <tal:item>
-          <a href="#" tal:attributes="href navigation_root_url">
-            <span class="menu-item-icon glyphicon glyphicon-home"></span> <span class="menu-item-title" i18n:translate="navigation_link_home">Home</span>
+        <tal:actions repeat="link links">
+          <a tal:attributes="href link/url;
+                             title link/title">
+            <span class="menu-item-icon glyphicon glyphicon-${link/icon}"></span> <span class="menu-item-title" tal:content="link/title"></span>
           </a>
-        </tal:item>
-
-        <tal:item tal:condition="view/is_anonymous">
-          <a href="#" tal:attributes="href python:portal_url + '/login'">
-            <span class="menu-item-icon glyphicon glyphicon-log-in"></span> <span class="menu-item-title" i18n:translate="navigation_link_login">Login</span>
-          </a>
-        </tal:item>
-
-        <tal:item tal:condition="not:view/is_anonymous">
-          <a href="#" tal:attributes="href python:portal_url + '/logout'">
-            <span class="menu-item-icon glyphicon glyphicon-log-out"></span> <span class="menu-item-title" i18n:translate="navigation_link_logout">Logout</span>
-          </a>
-        </tal:item>
+        </tal:actions>
 
       </div>
 

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -45,7 +45,7 @@
 
       </div>
 
-      <div class="menu-section" tal:define="links view/get_sidebar_links">
+      <div class="menu-section" tal:define="links view/get_static_links">
 
         <div class="menu-section-title" i18n:translate="navigation_heading_links">Links</div>
 

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -52,7 +52,7 @@
         <tal:actions repeat="link links">
           <a tal:attributes="href link/url;
                              title link/title">
-            <span class="menu-item-icon glyphicon glyphicon-${link/icon}"></span> <span class="menu-item-title" tal:content="link/title"></span>
+            <span class="menu-item-icon glyphicon ${link/icon}"></span> <span class="menu-item-title" tal:content="link/title"></span>
           </a>
         </tal:actions>
 

--- a/src/collective/sidebar/locales/collective.sidebar.pot
+++ b/src/collective/sidebar/locales/collective.sidebar.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-10 05:29+0000\n"
+"POT-Creation-Date: 2019-01-11 10:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,8 +25,20 @@ msgstr ""
 msgid "Collective Sidebar (collective.sidebar) - Uninstall"
 msgstr ""
 
+#: collective/sidebar/profiles/default/actions.xml
+msgid "Home"
+msgstr ""
+
 #: collective/sidebar/configure.zcml
 msgid "Installs the collective.sidebar add-on."
+msgstr ""
+
+#: collective/sidebar/profiles/default/actions.xml
+msgid "Login"
+msgstr ""
+
+#: collective/sidebar/profiles/default/actions.xml
+msgid "Logout"
 msgstr ""
 
 #: collective/sidebar/configure.zcml
@@ -101,21 +113,6 @@ msgstr ""
 #. Default: "Workflow"
 #: collective/sidebar/browser/templates/sidebar.pt
 msgid "navigation_heading_workflow"
-msgstr ""
-
-#. Default: "Home"
-#: collective/sidebar/browser/templates/sidebar.pt
-msgid "navigation_link_home"
-msgstr ""
-
-#. Default: "Login"
-#: collective/sidebar/browser/templates/sidebar.pt
-msgid "navigation_link_login"
-msgstr ""
-
-#. Default: "Logout"
-#: collective/sidebar/browser/templates/sidebar.pt
-msgid "navigation_link_logout"
 msgstr ""
 
 #. Default: "Settings"

--- a/src/collective/sidebar/locales/de/LC_MESSAGES/collective.sidebar.po
+++ b/src/collective/sidebar/locales/de/LC_MESSAGES/collective.sidebar.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-10 05:29+0000\n"
+"POT-Creation-Date: 2019-01-11 10:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,9 +22,21 @@ msgstr "Collective Sidebar (collective.sidebar)"
 msgid "Collective Sidebar (collective.sidebar) - Uninstall"
 msgstr "Collective Sidebar (collective.sidebar) - Uninstall"
 
+#: collective/sidebar/profiles/default/actions.xml
+msgid "Home"
+msgstr "Startseite"
+
 #: collective/sidebar/configure.zcml
 msgid "Installs the collective.sidebar add-on."
 msgstr "Installiert die Sidebar-Erweiterung"
+
+#: collective/sidebar/profiles/default/actions.xml
+msgid "Login"
+msgstr "Anmeldung"
+
+#: collective/sidebar/profiles/default/actions.xml
+msgid "Logout"
+msgstr "Abmelden"
 
 #: collective/sidebar/configure.zcml
 msgid "Uninstalls the collective.sidebar add-on."
@@ -99,21 +111,6 @@ msgstr "Webseite"
 #: collective/sidebar/browser/templates/sidebar.pt
 msgid "navigation_heading_workflow"
 msgstr "Arbeitsablauf"
-
-#. Default: "Home"
-#: collective/sidebar/browser/templates/sidebar.pt
-msgid "navigation_link_home"
-msgstr "Startseite"
-
-#. Default: "Login"
-#: collective/sidebar/browser/templates/sidebar.pt
-msgid "navigation_link_login"
-msgstr "Anmelden"
-
-#. Default: "Logout"
-#: collective/sidebar/browser/templates/sidebar.pt
-msgid "navigation_link_logout"
-msgstr "Abmelden"
 
 #. Default: "Settings"
 #: collective/sidebar/browser/templates/sidebar.pt

--- a/src/collective/sidebar/locales/de/LC_MESSAGES/collective.sidebar.po
+++ b/src/collective/sidebar/locales/de/LC_MESSAGES/collective.sidebar.po
@@ -32,7 +32,7 @@ msgstr "Installiert die Sidebar-Erweiterung"
 
 #: collective/sidebar/profiles/default/actions.xml
 msgid "Login"
-msgstr "Anmeldung"
+msgstr "Anmelden"
 
 #: collective/sidebar/profiles/default/actions.xml
 msgid "Logout"

--- a/src/collective/sidebar/profiles/default/actions.xml
+++ b/src/collective/sidebar/profiles/default/actions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <action-provider name="portal_workflow" />
+  <action-provider name="portal_types" />
+  <action-provider name="portal_actions" />
+
+  <object name="sidebar_links" meta_type="CMF Action Category">
+
+    <property name="title">Sidebar Links</property>
+
+    <object name="home" meta_type="CMF Action" i18n:domain="collective.sidebar">
+      <property name="title" i18n:translate="">Home</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:${portal_url}</property>
+      <property name="link_target"></property>
+      <property name="icon_expr">string:home</property>
+      <property name="available_expr"></property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="login" meta_type="CMF Action" i18n:domain="collective.sidebar">
+      <property name="title" i18n:translate="">Login</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:${portal_url}/login</property>
+      <property name="link_target"></property>
+      <property name="icon_expr">string:log-in</property>
+      <property name="available_expr">python:member is None</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="logout" meta_type="CMF Action" i18n:domain="collective.sidebar">
+      <property name="title" i18n:translate="">Logout</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:${portal_url}/logout</property>
+      <property name="link_target"></property>
+      <property name="icon_expr">string:log-out</property>
+      <property name="available_expr">python:member is not None</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/src/collective/sidebar/profiles/default/actions.xml
+++ b/src/collective/sidebar/profiles/default/actions.xml
@@ -14,7 +14,7 @@
       <property name="description" i18n:translate=""></property>
       <property name="url_expr">string:${portal_url}</property>
       <property name="link_target"></property>
-      <property name="icon_expr">string:home</property>
+      <property name="icon_expr">string:glyphicon-home</property>
       <property name="available_expr"></property>
       <property name="permissions">
         <element value="View" />
@@ -27,7 +27,7 @@
       <property name="description" i18n:translate=""></property>
       <property name="url_expr">string:${portal_url}/login</property>
       <property name="link_target"></property>
-      <property name="icon_expr">string:log-in</property>
+      <property name="icon_expr">string:glyphicon-log-in</property>
       <property name="available_expr">python:member is None</property>
       <property name="permissions">
         <element value="View" />
@@ -40,7 +40,7 @@
       <property name="description" i18n:translate=""></property>
       <property name="url_expr">string:${portal_url}/logout</property>
       <property name="link_target"></property>
-      <property name="icon_expr">string:log-out</property>
+      <property name="icon_expr">string:glyphicon-log-out</property>
       <property name="available_expr">python:member is not None</property>
       <property name="permissions">
         <element value="View" />

--- a/src/collective/sidebar/tests/test_actions.py
+++ b/src/collective/sidebar/tests/test_actions.py
@@ -43,3 +43,17 @@ class TestActionsFunctional(unittest.TestCase):
             home_el,
             self.viewlet(context=self.portal, request=self.request),
         )
+        # Add a new action to the sidebar_links
+        new_action_view = api.content.get_view(
+            name='new-action',
+            context=self.portal,
+            request=self.request,
+        )
+        new_action_view.createAndAdd({
+            'id': 'Contact',
+            'category': 'sidebar_links',
+        })
+        self.assertIn(
+            '<span class="menu-item-title">Contact</span>',
+            self.viewlet(context=self.portal, request=self.request),
+        )

--- a/src/collective/sidebar/tests/test_actions.py
+++ b/src/collective/sidebar/tests/test_actions.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from collective.sidebar.testing import COLLECTIVE_SIDEBAR_FUNCTIONAL_TESTING
+from plone import api
+from plone.app.testing import login
+from plone.app.testing import SITE_OWNER_NAME
+
+import unittest
+
+
+class TestActionsFunctional(unittest.TestCase):
+
+    layer = COLLECTIVE_SIDEBAR_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.nav_data_view = api.content.get_view(
+            name='navData',
+            context=self.portal,
+            request=self.request,
+        )
+        self.viewlet = self.nav_data_view.render_viewlet
+        self.portal_actions = api.portal.get_tool('portal_actions')
+        self.sidebar_links = self.portal_actions.get('sidebar_links')
+        login(self.portal, SITE_OWNER_NAME)
+
+    def test_action_links(self):
+        # Logout action only visible to authenticated users
+        self.assertIn(
+            '<span class="menu-item-title">Logout</span>',
+            self.viewlet(context=self.portal, request=self.request),
+        )
+        # Visibility should be respected
+        home_el = '<span class="menu-item-title">Home</span>'
+        self.assertIn(
+            home_el,
+            self.viewlet(context=self.portal, request=self.request),
+        )
+        home_link = self.sidebar_links.get('home')
+        home_link.visible = False
+        self.assertNotIn(
+            home_el,
+            self.viewlet(context=self.portal, request=self.request),
+        )


### PR DESCRIPTION
This has been implemented as part of #22.
The sidebar links are now configurable through the Plone portal_actions menu. There is now a new actions category `sidebar_links`...