### PR TITLE
Move Profile URL to Python

### DIFF
--- a/src/collective/sidebar/browser/sidebar.py
+++ b/src/collective/sidebar/browser/sidebar.py
@@ -61,9 +61,11 @@ class SidebarViewlet(ViewletBase):
         mtool = api.portal.get_tool('portal_membership')
         portrait = mtool.getPersonalPortrait(id=user[1])
         user_info = mtool.getMemberInfo(user[1])
+        portal_url = self.get_portal_url()
         data = {
             'user_info': user_info,
             'portrait': portrait.absolute_url(),
+            'user_url': portal_url + '/@@personal-information',
         }
         return data
 

--- a/src/collective/sidebar/browser/templates/sidebar.pt
+++ b/src/collective/sidebar/browser/templates/sidebar.pt
@@ -16,9 +16,10 @@
         <div class="menu-profile"
              tal:define="data view/get_user_data;
                          user_info data/user_info;
-                         portrait data/portrait">
+                         portrait data/portrait;
+                         user_url data/user_url">
 
-          <a href="${portal_url}/@@personal-information">
+          <a href="${user_url}">
 
             <div class="profile-image" style="background-image: url('${portrait}');"></div>
 


### PR DESCRIPTION
This moves the profile URL from the template to the Python class. A small hotfix which allows the method to be overriden in a third-party app.